### PR TITLE
filename fix

### DIFF
--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -151,6 +151,9 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
             else:
                 sys.stderr.write(py_exc.msg + '\n')
         return
+    if dfile is not None:
+        import _imp
+        _imp._fix_co_filename(code, file)
     try:
         dirname = os.path.dirname(cfile)
         if dirname:


### PR DESCRIPTION
I think _PyCode_Update is too late to fix the filename business.
This change fixes test_incorrect_code_name, but now test_module_without_source is failing. I'll look into that tomorrow (the problem is probably in the import stage, where it doesn't find the file).


